### PR TITLE
Added support for globallycoherent keyword.

### DIFF
--- a/GigiCompilerLib/Backends/DX12/Backend_DX12.cpp
+++ b/GigiCompilerLib/Backends/DX12/Backend_DX12.cpp
@@ -1550,6 +1550,8 @@ void CopyShaderFileDX12(const Shader& shader, const std::unordered_map<std::stri
                 {
                     case ShaderResourceType::Texture:
                     {
+                        const char* variablePrefix = (resource.access == ShaderResourceAccessType::UAV && resource.texture.globallyCoherent) ? "globallycoherent " : "";
+
                         const char* textureType = "";
                         switch (resource.texture.dimension)
                         {
@@ -1574,21 +1576,23 @@ void CopyShaderFileDX12(const Shader& shader, const std::unordered_map<std::stri
                         }
 
                         shaderSpecificStringReplacementMap["/*$(ShaderResources)*/"] <<
-                            "\n" << typePrefix << textureType << "<" << BackendDX12::DataFieldTypeToCPPType(viewDataFieldType) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
+                            "\n" << variablePrefix << typePrefix << textureType << "<" << BackendDX12::DataFieldTypeToCPPType(viewDataFieldType) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
                         break;
                     }
                     case ShaderResourceType::Buffer:
                     {
+						const char* variablePrefix = (resource.access == ShaderResourceAccessType::UAV && resource.buffer.globallyCoherent) ? "globallycoherent " : "";
+
                         if (resource.buffer.raw)
                         {
                             shaderSpecificStringReplacementMap["/*$(ShaderResources)*/"] <<
-                                "\n" << typePrefix << "ByteAddressBuffer " << resource.name << " : register(" << registerType << resource.registerIndex << ");"
+                                "\n" << variablePrefix << typePrefix << "ByteAddressBuffer " << resource.name << " : register(" << registerType << resource.registerIndex << ");"
                                 ;
                         }
                         else if (resource.buffer.typeStruct.structIndex != -1)
                         {
                             shaderSpecificStringReplacementMap["/*$(ShaderResources)*/"] <<
-                                "\n" << typePrefix << "StructuredBuffer<Struct_" << renderGraph.structs[resource.buffer.typeStruct.structIndex].name << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");"
+                                "\n" << variablePrefix << typePrefix << "StructuredBuffer<Struct_" << renderGraph.structs[resource.buffer.typeStruct.structIndex].name << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");"
                                 ;
                         }
                         else
@@ -1596,12 +1600,12 @@ void CopyShaderFileDX12(const Shader& shader, const std::unordered_map<std::stri
                             if (DataFieldTypeIsPOD(resource.buffer.type) && !resource.buffer.PODAsStructuredBuffer)
                             {
                                 shaderSpecificStringReplacementMap["/*$(ShaderResources)*/"] <<
-                                    "\n" << typePrefix << "Buffer<" << DataFieldTypeToShaderType(resource.buffer.type) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
+                                    "\n" << variablePrefix << typePrefix << "Buffer<" << DataFieldTypeToShaderType(resource.buffer.type) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
                             }
                             else
                             {
                                 shaderSpecificStringReplacementMap["/*$(ShaderResources)*/"] <<
-                                    "\n" << typePrefix << "StructuredBuffer<" << DataFieldTypeToShaderType(resource.buffer.type) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
+                                    "\n" << variablePrefix << typePrefix << "StructuredBuffer<" << DataFieldTypeToShaderType(resource.buffer.type) << "> " << resource.name << " : register(" << registerType << resource.registerIndex << ");";
                             }
                         }
                         break;

--- a/Schemas/SchemasShaders.h
+++ b/Schemas/SchemasShaders.h
@@ -261,11 +261,13 @@ STRUCT_BEGIN(ShaderResourceBuffer, "Data specific to buffers")
     STRUCT_FIELD(StructReference, typeStruct, {}, "The data type of the buffer if a struct type", 0)
     STRUCT_FIELD(bool, raw, false, "If true, will be viewed raw in the shader (E.g. DX12 ByteAddressBuffer)", 0)
     STRUCT_FIELD(bool, PODAsStructuredBuffer, true, "Set this to true if you want it to be StructuredBuffer instead of a Buffer, for non structure typed buffers.", 0)
+    STRUCT_FIELD(bool, globallyCoherent, false, "Set this to true if you want the resource to be declared as globallycoherent.", 0)
 STRUCT_END()
 
 STRUCT_BEGIN(ShaderResourceTexture, "Data specific to textures")
     STRUCT_FIELD(TextureDimensionType, dimension, TextureDimensionType::Texture2D, "The dimensionality of the texture", 0)
     STRUCT_FIELD(TextureViewType, viewType, TextureViewType::Float4, "The dimensionality of the texture", 0)
+	STRUCT_FIELD(bool, globallyCoherent, false, "Set this to true if you want the resource to be declared as globallycoherent.", 0)
 STRUCT_END()
 
 STRUCT_BEGIN(ShaderSampler, "Data specific to samplers")


### PR DESCRIPTION
Added the option to have buffers and textures be globallycoherent.

Currently the option is in the resource types (texture, buffer) specific settings, even though it applies to both. Because I didn't want to clutter the main dropdown.