### PR TITLE
Added settings for styling per graph.

### DIFF
--- a/GigiEdit/MakeUI.h
+++ b/GigiEdit/MakeUI.h
@@ -301,47 +301,66 @@ bool ShowUI(RenderGraph& renderGraph, const char* label, const char* tooltip, TS
     bool ret = false;
 
     ImGui::PushID(label);
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
+    // Special case where the array represents a color.
+    if ((_FLAGS & SCHEMA_FLAG_UI_COLOR) != 0 && (N == 3 || N == 4))
     {
-        ImGui::Text("%s[%i]", label, (int)N);
-        ShowUIToolTip(tooltip);
+        // Only enable this code path for float.
+        if constexpr (std::is_same_v<T, float>)
+        {
+			if (N == 3)
+			{
+				ImGui::ColorEdit3(label, value.data());
+			}
+			else if (N == 4)
+			{
+				ImGui::ColorEdit4(label, value.data());
+			}
+        }
     }
-
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
+    else
     {
-        float width = ImGui::GetContentRegionAvail().x / float(N + 2);
-        ImGui::PushItemWidth(width);
-    }
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
+		{
+			ImGui::Text("%s[%i]", label, (int)N);
+			ShowUIToolTip(tooltip);
+		}
 
-    bool showIndex = ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_HIDE_INDEX) == 0);
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
+		{
+			float width = ImGui::GetContentRegionAvail().x / float(N + 2);
+			ImGui::PushItemWidth(width);
+		}
 
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
-        ImGui::Indent();
+		bool showIndex = ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_HIDE_INDEX) == 0);
 
-    for (size_t index = 0; index < N; ++index)
-    {
-        ImGui::PushID((int)index);
-        char label[256];
-        sprintf_s(label, "[%i]", (int)index);
-        ret |= ShowUI(renderGraph, showIndex ? label : "", nullptr, value[index], path);
-        if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0 && index + 1 < N)
-            ImGui::SameLine();
-        ImGui::PopID();
-    }
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
+			ImGui::Indent();
 
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
-    {
-        ImGui::SameLine();
-        ImGui::Text("%s", label);
-        ShowUIToolTip(tooltip);
-    }
+		for (size_t index = 0; index < N; ++index)
+		{
+			ImGui::PushID((int)index);
+			char label[256];
+			sprintf_s(label, "[%i]", (int)index);
+			ret |= ShowUI(renderGraph, showIndex ? label : "", nullptr, value[index], path);
+			if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0 && index + 1 < N)
+				ImGui::SameLine();
+			ImGui::PopID();
+		}
 
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
-        ImGui::Unindent();
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
+		{
+			ImGui::SameLine();
+			ImGui::Text("%s", label);
+			ShowUIToolTip(tooltip);
+		}
 
-    if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
-    {
-        ImGui::PopItemWidth();
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) != 0)
+			ImGui::Unindent();
+
+		if ((_FLAGS & SCHEMA_FLAG_UI_ARRAY_FATITEMS) == 0)
+		{
+			ImGui::PopItemWidth();
+		}
     }
 
     ImGui::PopID();

--- a/GigiEdit/main.cpp
+++ b/GigiEdit/main.cpp
@@ -2219,6 +2219,42 @@ struct Example :
         }
     }
 
+    ax::NodeEditor::Utilities::NodeStyle GetNodeStyle(const RenderGraphNode& node)
+    {
+        auto GetColorFromArray = [](const std::array<float, 3>& arr, int32_t alpha) -> ImColor
+        {
+            return ImColor(arr[0], arr[1], arr[2], float(alpha) / 255.f);
+        };
+
+		// Default colors are from Frostbite FrameGraph
+        // slide 17 https://www.slideshare.net/DICEStudio/framegraph-extensible-rendering-architecture-in-frostbite
+
+        ax::NodeEditor::Utilities::NodeStyle result;
+        result.rounding = 12.f;
+        result.color = GetColorFromArray(g_renderGraph.styleSettings.actionNodeColor, 128);
+
+        if (GetNodeIsResourceNode(node))
+        {
+            result.rounding = 0.f;
+
+            bool isTransient = false;
+
+            // Use a different color for non transient resources.
+            if (node._index == RenderGraphNode::c_index_resourceBuffer)
+            {
+                isTransient = node.resourceBuffer.transient;
+            }
+            else if (node._index == RenderGraphNode::c_index_resourceTexture)
+            {
+                isTransient = node.resourceTexture.transient;
+            }
+
+            result.color = isTransient ? GetColorFromArray(g_renderGraph.styleSettings.resourceNodeColor, 128) : GetColorFromArray(g_renderGraph.styleSettings.nonTransientResourceNodeColor, 128);
+        }
+
+        return result;
+    }
+
     void OnFrame(float deltaTime) override
     {
         //ImGuiID dockspace_id = ImGui::DockSpaceOverViewport(nullptr);
@@ -2355,7 +2391,7 @@ struct Example :
                 }
             );
 
-            builder.Begin(nodeEditorId, GetNodeIsResourceNode(node), nodeDisabled);
+            builder.Begin(nodeEditorId, GetNodeStyle(node), nodeDisabled);
 
             if (g_renderGraphFirstFrame)
             {

--- a/GigiEdit/ui/builders.cpp
+++ b/GigiEdit/ui/builders.cpp
@@ -68,21 +68,17 @@ util::BlueprintNodeBuilder::BlueprintNodeBuilder(ImTextureID texture, int textur
 {
 }
 
-void util::BlueprintNodeBuilder::Begin(ed::NodeId id, bool isResourceNode, bool isDisabled)
+void util::BlueprintNodeBuilder::Begin(ed::NodeId id, NodeStyle nodeStyle, bool isDisabled)
 {
     HasHeader  = false;
     HeaderMin = HeaderMax = ImVec2();
 
-    // colors like Frostbite FrameGraph
-    // slide 17 https://www.slideshare.net/DICEStudio/framegraph-extensible-rendering-architecture-in-frostbite
-    ImColor color = isResourceNode ? ImColor(128, 128, 255, 128) : ImColor(255, 128, 64, 128);
-
     if (isDisabled)
-        color.Value.w /= 4.0f;
+        nodeStyle.color.Value.w /= 4.0f;
 
     ed::PushStyleVar(StyleVar_NodePadding, ImVec4(3, 3, 3, 3));
-	ed::PushStyleVar(StyleVar_NodeRounding, isResourceNode ? 0.0f : 12.0f);
-	ed::PushStyleColor(ed::StyleColor_NodeBg, color);
+	ed::PushStyleVar(StyleVar_NodeRounding, nodeStyle.rounding);
+	ed::PushStyleColor(ed::StyleColor_NodeBg, nodeStyle.color);
 	ed::PushStyleColor(ed::StyleColor_NodeBorder, ImColor(0, 0, 0, 64));
 
     ed::BeginNode(id);

--- a/GigiEdit/ui/builders.h
+++ b/GigiEdit/ui/builders.h
@@ -21,11 +21,17 @@ namespace Utilities {
 
 
 //------------------------------------------------------------------------------
+struct NodeStyle
+{
+    ImColor color;
+    float rounding;
+};
+
 struct BlueprintNodeBuilder
 {
     BlueprintNodeBuilder(ImTextureID texture = nullptr, int textureWidth = 0, int textureHeight = 0);
 
-    void Begin(NodeId id, bool isResourceNode, bool isDisabled);
+    void Begin(NodeId id, NodeStyle nodeStyle, bool isDisabled);
     void End();
 
     void Header(const ImVec4& color = ImVec4(1, 1, 1, 1));

--- a/Schemas/Schemas.h
+++ b/Schemas/Schemas.h
@@ -86,6 +86,12 @@ STRUCT_BEGIN(ConfigFromBackend, "Frontend configuration set by the backend.")
     STRUCT_FIELD(bool, RTSceneTakesSRVSlot, true, "If true, RT scenes will take an SRV register slot.", 0)
 STRUCT_END()
 
+STRUCT_BEGIN(StyleSettings, "Graph style settings.")
+    STRUCT_STATIC_ARRAY(float, resourceNodeColor, 3, { 128.f / 255.f COMMA 128.f / 255.f COMMA 1.f }, "Color of the resource node types.", SCHEMA_FLAG_UI_COLOR)
+    STRUCT_STATIC_ARRAY(float, nonTransientResourceNodeColor, 3, { 128.f / 255.f COMMA 128.f / 255.f COMMA 1.f }, "Color of the non transient resource node types.", SCHEMA_FLAG_UI_COLOR)
+    STRUCT_STATIC_ARRAY(float, actionNodeColor, 3, { 1.f COMMA 128.f / 255.f COMMA 64.f / 255.f }, "Color of the action node types.", SCHEMA_FLAG_UI_COLOR)
+STRUCT_END()
+
 STRUCT_BEGIN(ResourceTransition, "A single resource transition")
     STRUCT_FIELD(int, nodeIndex, -1, "The node for the resource being transitioned.", 0)
     STRUCT_FIELD(ShaderResourceAccessType, oldState, ShaderResourceAccessType::Count, "The previous state", 0)
@@ -191,6 +197,8 @@ STRUCT_BEGIN(RenderGraph, "The root type of the render graph")
     STRUCT_FIELD(BackendSettings, settings, {}, "Backend settings", SCHEMA_FLAG_UI_COLLAPSABLE)
 
     STRUCT_FIELD(BuildSettings, buildSettings, {}, "Build settings", SCHEMA_FLAG_UI_COLLAPSABLE)
+
+    STRUCT_FIELD(StyleSettings, styleSettings, {}, "Style settings", SCHEMA_FLAG_UI_COLLAPSABLE)
 
     STRUCT_DYNAMIC_ARRAY(CustomGigiToken, customTokens, "Allows you to give values for custom gigi tokens, such as /*$(CopyrightHeader)*/. All unknown Gigi tokens are replaced with empty string by default.", 0)
 

--- a/external/df_serialize/Config.h
+++ b/external/df_serialize/Config.h
@@ -47,3 +47,4 @@
 #define SCHEMA_FLAG_UI_MULTILINETEXT		((size_t) (1 << 5))  // if true, the text edit box is multiline
 #define SCHEMA_FLAG_UI_ARRAY_HIDE_INDEX		((size_t) (1 << 6))  // If true, does not show the index of array items
 #define SCHEMA_FLAG_UI_CONST				((size_t) (1 << 7))  // If true, does not allow field to be edited
+#define SCHEMA_FLAG_UI_COLOR				((size_t) (1 << 8))  // If true, this value will be displayed as a color picker.


### PR DESCRIPTION
This pull requests adds styling options per graph. This allows the user to change the colors of the nodes.
Also added a secondary color for non transient resources.

This change was originally just a want for different colors for non transient resources, but decided to expand it out so you can change the color of all nodes. The default colors are still the same as before.

Not sure if it's something that is wanted, but made a pull request just in case.