### PR TITLE
fix for texture2darray readback

### DIFF
--- a/GigiViewerDX12/ImageReadback.cpp
+++ b/GigiViewerDX12/ImageReadback.cpp
@@ -226,7 +226,7 @@ namespace ImageReadback
 
         // Map the memory
         D3D12_RANGE readRange;
-        readRange.Begin = layout.Offset + y * layout.Footprint.RowPitch + x * formatInfo.bytesPerPixel + z * layout.Footprint.Height * layout.Footprint.RowPitch;
+        readRange.Begin = layout.Offset + y * layout.Footprint.RowPitch + x * formatInfo.bytesPerPixel;
         readRange.End = readRange.Begin + formatInfo.bytesPerPixel;
         unsigned char* readbackData = nullptr;
         HRESULT hr = readbackResource->Map(0, &readRange, (void**)&readbackData);


### PR DESCRIPTION
texture2darray readback went out of bounds when selecting high array index: 
not adding z * height * rowpitch to the readRange.Begin fixes this.
the layout.offset already contains this subresource offset. 