### PR TITLE
Fsr bug fix

### DIFF
--- a/GigiViewerDX12/AMDFrameInterpolation.cpp
+++ b/GigiViewerDX12/AMDFrameInterpolation.cpp
@@ -823,7 +823,22 @@ namespace AMDFrameInterpolation
         HANDLE_TEXTURE(uiTexture);
 
         if (!textureExists_depth || !textureExists_motionVectors)
+        {
+            // If we have a context, we need to make sure we don't have a stale callback registered
+            if (s_state.m_FrameGenContext)
+            {
+                ffx::ConfigureDescFrameGeneration frameGenerationConfigDesc = {};
+                frameGenerationConfigDesc.header.type = FFX_API_CONFIGURE_DESC_TYPE_FRAMEGENERATION;
+                frameGenerationConfigDesc.swapChain = swapChain;
+                frameGenerationConfigDesc.frameGenerationEnabled = false;
+                frameGenerationConfigDesc.presentCallback = nullptr;
+                frameGenerationConfigDesc.presentCallbackUserContext = nullptr;
+                frameGenerationConfigDesc.frameID = desc.frameIndex;
+
+                ffx::Configure(s_state.m_FrameGenContext, frameGenerationConfigDesc);
+            }
             return;
+        }
 
 #undef HANDLE_TEXTURE
 

--- a/Techniques/UnitTests/AMD/Upscale.gguser
+++ b/Techniques/UnitTests/AMD/Upscale.gguser
@@ -44,6 +44,7 @@
         ]
     },
     "AMDFrameInterpolation": {
+        "fsrUIRenderMode": 0,
         "ENABLE_DEBUG_CHECKING": false,
         "depth": "Depth",
         "motionVectors": "Motion_Vectors",


### PR DESCRIPTION
Clear the present callback in `Tick` if required input textures (depth, motion vectors) are missing. This fixes artifacts caused by stale callbacks when switching from an FSR-enabled level to one without FSR support.