### PR TITLE
Fix multiplication order for glTF transforms

### DIFF
--- a/GigiViewerDX12/DX12Utils/SceneDataCache_GLTF.cpp
+++ b/GigiViewerDX12/DX12Utils/SceneDataCache_GLTF.cpp
@@ -294,7 +294,7 @@ bool SceneDataCache::LoadGLTF(FileCache::File& fileData, SceneData& sceneData)
                 relXForm = scale * rotation * translation;
             }
 
-            DirectX::XMMATRIX xForm = parentXForm * relXForm;
+            DirectX::XMMATRIX xForm = relXForm * parentXForm;
 
             if (node.light >= 0)
             {


### PR DESCRIPTION
Currently, the matrix multiplication order seems wrong when loading glTF files. This change proposes a fix for this. 

Testing with the Bistro scene from [https://github.com/NVIDIA-RTX/RTXDI-Assets](https://github.com/NVIDIA-RTX/RTXDI-Assets):

Before:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/1f1f8f5b-292e-4529-b25a-1b93b92e2044" />

After:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/d3a4b30b-9024-4110-8b15-451acf9487e0" />
